### PR TITLE
rename InvalidArgument to InvalidDocument

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,80 @@ Brazanation Documents
 
 A PHP library to provide Brazilian Documents safer, easier and fun!
 
-```shell
-$ composer require brazanation/documents
+Installation
+------------
+
+Install the library using [composer][1]. Add the following to your `composer.json`:
+
+```json
+{
+    "require": {
+        "brazanation/documents": "0.1.*"
+    }
+}
 ```
+
+Now run the `install` command.
+
+```sh
+$ composer.phar install
+```
+
+or
+
+```sh
+$ composer require brazanation/documents 0.1.*
+```
+
+#### CPF (cadastro de pessoas físicas)
+
+Registration of individuals or Tax Identification
 
 ```php
 use Brazanation\Documents\Cpf;
-use Brazanation\Documents\Cnpj;
-use Brazanation\Documents\PisPasep;
+use Brazanation\Documents\Exception\InvalidDocument as  InvalidDocumentException;
 
-$cpf = new Cpf('06843273173');
-
-$cnpj = new Cnpj('99999090910270');
-
-$pispasep = new PisPasep('51.82312.94-92');
+try {
+    $cpf = new Cpf('06843273173');
+    echo $cpf->format(); // prints 068.432.731-73
+catch (InvalidDocumentException $e){
+    echo $e->getMessage();
+}
 ```
 
-If number is not valid, it will throw an exception!
+#### CNPJ (cadastro nacional da pessoa jurídica)
+
+Company Identification or National Register of Legal Entities
+```php
+use Brazanation\Documents\Cnpj;
+use Brazanation\Documents\Exception\InvalidDocument as  InvalidDocumentException;
+
+try {
+    $cnpj = new Cnpj('99999090910270');
+    echo $cnpj->format(); // prints 99.999.090/9102-70
+catch (InvalidDocumentException $e){
+    echo $e->getMessage();
+}
+```
+
+#### PIS/PASEP (programa de integração social e programa de formação do patrimônio do servidor público)
+
+Social Integration Program and Training Program of the Heritage of Public Servant
+
+```php
+use Brazanation\Documents\PisPasep;
+use Brazanation\Documents\Exception\InvalidDocument as  InvalidDocumentException;
+
+try {
+    $pispasep = new PisPasep('51.82312.94-92');
+    echo $pispasep->format(); // print 51.82312.94-92
+catch (InvalidDocumentException $e){
+    echo $e->getMessage();
+}
+```
+
+### License
+
+MIT, hell yeah!
+
+[1]: http://getcomposer.org/

--- a/src/Cnpj.php
+++ b/src/Cnpj.php
@@ -2,7 +2,7 @@
 
 namespace Brazanation\Documents;
 
-use Brazanation\Documents\Exception\InvalidArgument as InvalidArgumentException;
+use Brazanation\Documents\Exception\InvalidDocument as InvalidArgumentException;
 
 final class Cnpj implements DocumentInterface
 {

--- a/src/Cpf.php
+++ b/src/Cpf.php
@@ -2,7 +2,7 @@
 
 namespace Brazanation\Documents;
 
-use Brazanation\Documents\Exception\InvalidArgument as InvalidArgumentException;
+use Brazanation\Documents\Exception\InvalidDocument as InvalidArgumentException;
 
 final class Cpf implements DocumentInterface
 {

--- a/src/Exception/InvalidDocument.php
+++ b/src/Exception/InvalidDocument.php
@@ -2,7 +2,7 @@
 
 namespace Brazanation\Documents\Exception;
 
-class InvalidArgument extends \InvalidArgumentException
+class InvalidDocument extends \InvalidArgumentException
 {
     public static function notEmpty($type)
     {

--- a/src/PisPasep.php
+++ b/src/PisPasep.php
@@ -2,7 +2,7 @@
 
 namespace Brazanation\Documents;
 
-use Brazanation\Documents\Exception\InvalidArgument;
+use Brazanation\Documents\Exception\InvalidDocument;
 
 final class PisPasep implements DocumentInterface
 {
@@ -35,10 +35,10 @@ final class PisPasep implements DocumentInterface
     private function validate($pispasep)
     {
         if (empty($pispasep)) {
-            throw InvalidArgument::notEmpty(static::LABEL);
+            throw InvalidDocument::notEmpty(static::LABEL);
         }
         if (!$this->isValidCV($pispasep)) {
-            throw InvalidArgument::isNotValid(static::LABEL, $pispasep);
+            throw InvalidDocument::isNotValid(static::LABEL, $pispasep);
         }
     }
 

--- a/tests/DocumentTestCase.php
+++ b/tests/DocumentTestCase.php
@@ -3,7 +3,7 @@
 namespace Brazanation\Documents\Tests;
 
 use Brazanation\Documents\DocumentInterface;
-use Brazanation\Documents\Exception\InvalidArgument;
+use Brazanation\Documents\Exception\InvalidDocument;
 
 abstract class DocumentTestCase extends \PHPUnit_Framework_TestCase
 {
@@ -73,7 +73,7 @@ abstract class DocumentTestCase extends \PHPUnit_Framework_TestCase
      */
     final public function testShouldThrowExceptionForEmptyData($documentType, $number)
     {
-        $this->expectException(InvalidArgument::class);
+        $this->expectException(InvalidDocument::class);
         $this->expectExceptionMessage("The {$documentType} must not be empty");
         $this->createDocument($number);
     }
@@ -86,7 +86,7 @@ abstract class DocumentTestCase extends \PHPUnit_Framework_TestCase
      */
     public function testShouldThrowExceptionForInvalidNumbers($documentType, $number)
     {
-        $this->expectException(InvalidArgument::class);
+        $this->expectException(InvalidDocument::class);
         $this->expectExceptionMessage("The {$documentType}($number) is not valid");
         $this->createDocument($number);
     }


### PR DESCRIPTION
keeping close with validation name and improvements in README.md
