### PR TITLE
Fix skipped test for Renavam

### DIFF
--- a/src/Renavam.php
+++ b/src/Renavam.php
@@ -20,8 +20,21 @@ final class Renavam extends AbstractDocument
     public function __construct($renavam)
     {
         $renavam = preg_replace('/\D/', '', $renavam);
-        $renavam = str_pad($renavam, self::LENGTH, 0, STR_PAD_LEFT);
+        $renavam = $this->padNumber($renavam);
         parent::__construct($renavam, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
+    }
+
+    /**
+     * @param string $number
+     * @return string
+     */
+    private function padNumber($number)
+    {
+        if (empty($number)) {
+            return '';
+        }
+
+        return str_pad($number, self::LENGTH, 0, STR_PAD_LEFT);
     }
 
     /**

--- a/src/Renavam.php
+++ b/src/Renavam.php
@@ -25,7 +25,10 @@ final class Renavam extends AbstractDocument
     }
 
     /**
+     * Pad left a number to length(11) with 0(ZERO)
+     *
      * @param string $number
+     *
      * @return string
      */
     private function padNumber($number)

--- a/tests/RenavamTest.php
+++ b/tests/RenavamTest.php
@@ -29,7 +29,10 @@ class RenavamTest extends DocumentTestCase
 
     public function provideEmptyData()
     {
-        return [];
+        return [
+            [Renavam::LABEL, ''],
+            [Renavam::LABEL, null],
+        ];
     }
 
     public function provideInvalidNumber()


### PR DESCRIPTION
Tests to validate empty number was skipped because it was empty. It is
prepared to throw exception when given number is empty or null.