### PR TITLE
Updated to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: php
 dist: trusty
 
 php:
-  - 5.6
   - 7.0
-  - hhvm
 
 before_script:
   - "composer self-update"

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "Provides Brazilian Documents",
     "type": "library",
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.5",
+        "phpunit/phpunit": "^6.4",
         "codacy/coverage": "^1.0"
     },
     "license": "MIT",

--- a/tests/DigitCalculatorTest.php
+++ b/tests/DigitCalculatorTest.php
@@ -3,8 +3,9 @@
 namespace Brazanation\Documents\Tests;
 
 use Brazanation\Documents\DigitCalculator;
+use PHPUnit\Framework\TestCase;
 
-class DigitCalculatorTest extends \PHPUnit_Framework_TestCase
+class DigitCalculatorTest extends TestCase
 {
     /**
      * @param string $number

--- a/tests/DocumentTestCase.php
+++ b/tests/DocumentTestCase.php
@@ -4,8 +4,9 @@ namespace Brazanation\Documents\Tests;
 
 use Brazanation\Documents\AbstractDocument;
 use Brazanation\Documents\Exception\InvalidDocument;
+use PHPUnit\Framework\TestCase;
 
-abstract class DocumentTestCase extends \PHPUnit_Framework_TestCase
+abstract class DocumentTestCase extends TestCase
 {
     /**
      * @param string $number


### PR DESCRIPTION
For a future release of this package, I've already updated the PHPUnit for `^6.4`.

Dropped support to `PHP 5.6` and `HHVM`, as PHPUnit 6.0 [requires PHP 7.0](https://github.com/sebastianbergmann/phpunit/blob/master/composer.json#L25).