### PR TITLE
Add new way to create a Document objects

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -7,7 +7,6 @@ enabled:
     - no_unused_imports
     - no_whitespace_in_blank_lines
     - ordered_imports
-    - phpdoc_align
     - phpdoc_separation
     - return
     - short_array_syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 Change Log
 ==========
 
+## [v0.8.0](https://github.com/brazanation/documents/tree/v0.8.0) (2018-02-17)
+[Full Changelog](https://github.com/brazanation/documents/compare/v0.7.1...v0.8.0)
+
+**Implemented enhancements:**
+
+- Add Judiciary Process document [#38](https://github.com/brazanation/documents/pull/38) ([robmachado](https://github.com/robmachado))
+- Detail how Judiciary Process number is composed [#41](https://github.com/brazanation/documents/pull/41) ([tonicospinelli](https://github.com/tonicospinelli))
+
+**Fixed bugs:**
+
+- Fix StyleCI configuration [#40](https://github.com/brazanation/documents/pull/40) ([tonicospinelli](https://github.com/tonicospinelli))
+
+**Closed issues:**
+
+**Merged pull requests:**
+
+- Add Judiciary Process document [#38](https://github.com/brazanation/documents/pull/38) ([robmachado](https://github.com/robmachado))
+- Fix StyleCI configuration [#40](https://github.com/brazanation/documents/pull/40) ([tonicospinelli](https://github.com/tonicospinelli))
+- Detail how Judiciary Process number is composed [#41](https://github.com/brazanation/documents/pull/41) ([tonicospinelli](https://github.com/tonicospinelli))
+
 ## [v0.7.1](https://github.com/brazanation/documents/tree/v0.7.1) (2018-02-17)
 [Full Changelog](https://github.com/brazanation/documents/compare/v0.7.0...v0.7.1)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install the library using [composer][1]. Add the following to your `composer.jso
 ```json
 {
     "require": {
-        "brazanation/documents": "0.7.*"
+        "brazanation/documents": "0.8.*"
     }
 }
 ```
@@ -31,7 +31,7 @@ $ composer.phar install
 or
 
 ```sh
-$ composer require brazanation/documents 0.7.*
+$ composer require brazanation/documents 0.8.*
 ```
 
 ### CPF (cadastro de pessoas físicas)
@@ -40,13 +40,25 @@ Registration of individuals or Tax Identification
 
 ```php
 use Brazanation\Documents\Cpf;
+
+$document = Cpf::createFromString('06843273173');
+if (false === $cpf) {
+   echo "Not Valid";
+}
+echo $document; // prints 06843273173
+echo $document->format(); // prints 068.432.731-73
+
+```
+or
+```php
+use Brazanation\Documents\Cpf;
 use Brazanation\Documents\Exception\InvalidDocument as  InvalidDocumentException;
 
 try {
-    $cpf = new Cpf('06843273173');
-    echo $cpf; // prints 06843273173
-    echo $cpf->format(); // prints 068.432.731-73
-}catch (InvalidDocumentException $e){
+    $document = new Cpf('06843273173');
+    echo $document; // prints 06843273173
+    echo $document->format(); // prints 068.432.731-73
+} catch (InvalidDocumentException $e) {
     echo $e->getMessage();
 }
 ```
@@ -57,15 +69,14 @@ Company Identification or National Register of Legal Entities
 
 ```php
 use Brazanation\Documents\Cnpj;
-use Brazanation\Documents\Exception\InvalidDocument as  InvalidDocumentException;
 
-try {
-    $cnpj = new Cnpj('99999090910270');
-    echo $cnpj; // prints 99999090910270
-    echo $cnpj->format(); // prints 99.999.090/9102-70
-}catch (InvalidDocumentException $e){
-    echo $e->getMessage();
+$document = Cnpj::createFromString('99999090910270');
+
+if (false === $document) {
+   echo "Not Valid";
 }
+echo $document; // prints 99999090910270
+echo $document->format(); // prints 99.999.090/9102-70
 ```
 
 ### CNH (carteira nacional de habilitação)
@@ -74,15 +85,14 @@ National Driving License
 
 ```php
 use Brazanation\Documents\Cnh;
-use Brazanation\Documents\Exception\InvalidDocument as  InvalidDocumentException;
 
-try {
-    $cnh = new Cnh('83592802666');
-    echo $cnh; // prints 83592802666
-    echo $cnh->format(); // prints 83592802666
-}catch (InvalidDocumentException $e){
-    echo $e->getMessage();
+$document = Cnh::createFromString('83592802666');
+
+if (false === $document) {
+   echo "Not Valid";
 }
+echo $cnh; // prints 83592802666
+echo $cnh->format(); // prints 83592802666
 ```
 
 ### Chave de Acesso Sped (chave da NFe, CTe e MDFe)
@@ -98,15 +108,14 @@ Available models:
 
 ```php
 use Brazanation\Documents\Sped\NFe;
-use Brazanation\Documents\Exception\InvalidDocument as  InvalidDocumentException;
 
-try {
-    $accessKey = new NFe('52060433009911002506550120000007801267301613');
-    echo $accessKey; // prints 52060433009911002506550120000007801267301613
-    echo $accessKey->format(); // prints 5206 0433 0099 1100 2506 5501 2000 0007 8012 6730 1613
-}catch (InvalidDocumentException $e){
-    echo $e->getMessage();
+$document = NFe::createFromString('52060433009911002506550120000007801267301613');
+
+if (false === $document) {
+   echo "Not Valid";
 }
+echo $document; // prints 52060433009911002506550120000007801267301613
+echo $document->format(); // prints 5206 0433 0099 1100 2506 5501 2000 0007 8012 6730 1613
 ```
 or generate your number
 
@@ -133,15 +142,15 @@ Social Integration Program and Training Program of the Heritage of Public Servan
 
 ```php
 use Brazanation\Documents\PisPasep;
-use Brazanation\Documents\Exception\InvalidDocument as  InvalidDocumentException;
 
-try {
-    $pispasep = new PisPasep('51.82312.94-92');
-    echo $pispasep; // prints 51823129492
-    echo $pispasep->format(); // prints 51.82312.94-92
-}catch (InvalidDocumentException $e){
-    echo $e->getMessage();
+$document = PisPasep::createFromString('51.82312.94-92');
+
+if (false === $document) {
+   echo "Not Valid";
 }
+
+echo $document; // prints 51823129492
+echo $document->format(); // prints 51.82312.94-92
 ```
 
 ### Título de Eleitor
@@ -150,16 +159,16 @@ Voter Registration
 
 ```php
 use Brazanation\Documents\Voter;
-use Brazanation\Documents\Exception\InvalidDocument as  InvalidDocumentException;
 
-try {
-    $voter = new Voter('106644440302', 20, 42);
-    echo $voter; // prints 106644440302
-    echo $voter->getSection(); // prints 0020
-    echo $voter->getZone(); // prints 042
-}catch (InvalidDocumentException $e){
-    echo $e->getMessage();
+$document = Voter::createFromString('106644440302', 20, 42);
+
+if (false === $document) {
+   echo "Not Valid";
 }
+
+echo $document; // prints 106644440302
+echo $document->getSection(); // prints 0020
+echo $document->getZone(); // prints 042
 ```
 
 ### Inscrição Estadual
@@ -168,11 +177,6 @@ State Registration
 
 ```php
 use Brazanation\Documents\StateRegistration;
-use Brazanation\Documents\Exception\InvalidDocument as  InvalidDocumentException;
-
-$state = StateRegistration::AC('0100482300112');
-echo $state; // prints 0100482300112
-echo $state->format(); // prints 01.004.823/001-12
 
 // for Commercial São Paulo
 $state = StateRegistration::SP('110.042.490.114');
@@ -184,6 +188,17 @@ $state = StateRegistration::SP('P011004243002');
 echo $state; // prints P011004243002
 echo $state->format(); // prints P-01100424.3/002
 ```
+or
+```php
+use Brazanation\Documents\StateRegistration;
+
+$document = StateRegistration::createFromString('P011004243002', 'SP');
+
+if (false === $document) {
+   echo "Not Valid";
+}
+
+```
 
 ### Cartão Nacional de Saúde (SUS)
 
@@ -192,9 +207,14 @@ National Health Card
 ```php
 use Brazanation\Documents\Cns;
 
-$cns = new Cns('242912018460005')
-echo $cns; // prints 242912018460005
-echo $cns->format(); // prints 242 9120 1846 0005
+$document = Cns::createFromString('242912018460005');
+
+if (false === $document) {
+   echo "Not Valid";
+}
+
+echo $document; // prints 242912018460005
+echo $document->format(); // prints 242 9120 1846 0005
 ```
 
 ### Renavam (Registro Nacional de Veículos Automotores)
@@ -204,9 +224,14 @@ National Registry of Motor Vehicles
 ```php
 use Brazanation\Documents\Renavam;
 
-$renavam = new Renavam('61855253306')
-echo $renavam; // prints 61855253306
-echo $renavam->format(); // prints 6185.525330-6
+$document = Renavam::createFromString('61855253306');
+
+if (false === $document) {
+   echo "Not Valid";
+}
+
+echo $document; // prints 61855253306
+echo $document->format(); // prints 6185.525330-6
 ```
 
 ### Processos Judiciais
@@ -216,9 +241,14 @@ Numbers of legal proceedings related to Judiciary assessments
 ```php
 use Brazanation\Documents\JudiciaryProcess;
 
-$procjud = new JudiciaryProcess('0048032982009809');
-echo $procjud; //prints  0048032982009809
-echo $procjud->format(); //prints  0048032.98.2009.8.09.0000
+$document = JudiciaryProcess::createFromString('0048032982009809');
+
+if (false === $document) {
+   echo "Not Valid";
+}
+
+echo $document; //prints  0048032982009809
+echo $document->format(); //prints  0048032.98.2009.8.09.0000
 
 ```
 

--- a/src/Cnh.php
+++ b/src/Cnh.php
@@ -10,6 +10,8 @@ final class Cnh extends AbstractDocument
 
     const REGEX = '/^([\d]{3})([\d]{3})([\d]{4})([\d]{1})$/';
 
+    const NUMBER_OF_DIGITS = 2;
+
     /**
      * Cnh constructor.
      *
@@ -18,7 +20,12 @@ final class Cnh extends AbstractDocument
     public function __construct($cnh)
     {
         $cnh = preg_replace('/\D/', '', $cnh);
-        parent::__construct($cnh, self::LENGTH, 2, self::LABEL);
+        parent::__construct($cnh, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
+    }
+
+    public static function createFromString($number)
+    {
+        return parent::tryCreateFromString(self::class, $number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
     }
 
     /**

--- a/src/Cnpj.php
+++ b/src/Cnpj.php
@@ -10,6 +10,8 @@ final class Cnpj extends AbstractDocument
 
     const REGEX = '/^([\d]{2})([\d]{3})([\d]{3})([\d]{4})([\d]{2})$/';
 
+    const NUMBER_OF_DIGITS = 2;
+
     /**
      * Cnpj constructor.
      *
@@ -18,7 +20,12 @@ final class Cnpj extends AbstractDocument
     public function __construct($cnpj)
     {
         $cnpj = preg_replace('/\D/', '', $cnpj);
-        parent::__construct($cnpj, self::LENGTH, 2, self::LABEL);
+        parent::__construct($cnpj, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
+    }
+
+    public static function createFromString($number)
+    {
+        return parent::tryCreateFromString(self::class, $number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
     }
 
     /**

--- a/src/Cns.php
+++ b/src/Cns.php
@@ -15,7 +15,7 @@ final class Cns extends AbstractDocument
 
     const FORMAT = '$1 $2 $3 $4';
 
-    const DIGIT_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     /**
      * CNS constructor.
@@ -25,7 +25,12 @@ final class Cns extends AbstractDocument
     public function __construct($number)
     {
         $number = preg_replace('/\D/', '', $number);
-        parent::__construct($number, self::LENGTH, self::DIGIT_COUNT, self::LABEL);
+        parent::__construct($number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
+    }
+
+    public static function createFromString($number)
+    {
+        return parent::tryCreateFromString(self::class, $number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
     }
 
     /**

--- a/src/Cpf.php
+++ b/src/Cpf.php
@@ -10,6 +10,8 @@ final class Cpf extends AbstractDocument
 
     const REGEX = '/^([\d]{3})([\d]{3})([\d]{3})([\d]{2})$/';
 
+    const NUMBER_OF_DIGITS = 2;
+
     /**
      * Cpf constructor.
      *
@@ -18,7 +20,12 @@ final class Cpf extends AbstractDocument
     public function __construct($number)
     {
         $number = preg_replace('/\D/', '', $number);
-        parent::__construct($number, self::LENGTH, 2, self::LABEL);
+        parent::__construct($number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
+    }
+
+    public static function createFromString($number)
+    {
+        return parent::tryCreateFromString(self::class, $number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
     }
 
     /**

--- a/src/JudiciaryProcess.php
+++ b/src/JudiciaryProcess.php
@@ -22,6 +22,8 @@ final class JudiciaryProcess extends AbstractDocument
 
     const REGEX = '/^([\d]{7})([\d]{2})([\d]{4})([\d]{1})([\d]{2})([\d]{0,4})$/';
 
+    const NUMBER_OF_DIGITS = 2;
+
     /**
      * Identify sequential number of process by origin unit.
      *
@@ -61,7 +63,12 @@ final class JudiciaryProcess extends AbstractDocument
     {
         $number = preg_replace('/\D/', '', $number);
         $this->extractNumbers($number);
-        parent::__construct($number, self::LENGTH, 2, self::LABEL);
+        parent::__construct($number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
+    }
+
+    public static function createFromString($number)
+    {
+        return parent::tryCreateFromString(self::class, $number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
     }
 
     /**

--- a/src/PisPasep.php
+++ b/src/PisPasep.php
@@ -10,6 +10,8 @@ final class PisPasep extends AbstractDocument
 
     const REGEX = '/^([\d]{3})([\d]{5})([\d]{2})([\d]{1})$/';
 
+    const NUMBER_OF_DIGITS = 1;
+
     /**
      * PisPasep constructor.
      *
@@ -18,7 +20,12 @@ final class PisPasep extends AbstractDocument
     public function __construct($number)
     {
         $number = preg_replace('/\D/', '', $number);
-        parent::__construct($number, self::LENGTH, 1, self::LABEL);
+        parent::__construct($number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
+    }
+
+    public static function createFromString($number)
+    {
+        return parent::tryCreateFromString(self::class, $number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
     }
 
     /**

--- a/src/Renavam.php
+++ b/src/Renavam.php
@@ -24,6 +24,11 @@ final class Renavam extends AbstractDocument
         parent::__construct($renavam, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
     }
 
+    public static function createFromString($number)
+    {
+        return parent::tryCreateFromString(self::class, $number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
+    }
+
     /**
      * Pad left a number to length(11) with 0(ZERO)
      *

--- a/src/Sped/AbstractAccessKey.php
+++ b/src/Sped/AbstractAccessKey.php
@@ -23,13 +23,15 @@ use Brazanation\Documents\Sped\Exception\DocumentModel;
  */
 abstract class AbstractAccessKey extends AbstractDocument
 {
+    const NUMBER_OF_DIGITS = 1;
+
     const LABEL = 'SpedAccessKey';
 
     const LENGTH = 44;
 
-    const REGEX = '/([\d]{4})/';
-
     const MASK = '$1 ';
+
+    const REGEX = '/([\d]{4})/';
 
     /**
      * @var int
@@ -79,9 +81,14 @@ abstract class AbstractAccessKey extends AbstractDocument
     public function __construct($accessKey)
     {
         $accessKey = preg_replace('/\D/', '', $accessKey);
-        parent::__construct($accessKey, static::LENGTH, 1, static::LABEL);
+        parent::__construct($accessKey, static::LENGTH, static::NUMBER_OF_DIGITS, static::LABEL);
         $this->validateModel($accessKey);
         $this->loadFromKey($accessKey);
+    }
+
+    public static function createFromString($number)
+    {
+        return parent::tryCreateFromString(static::class, $number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
     }
 
     /**

--- a/src/StateRegistration.php
+++ b/src/StateRegistration.php
@@ -2,35 +2,6 @@
 
 namespace Brazanation\Documents;
 
-use Brazanation\Documents\StateRegistration\Acre;
-use Brazanation\Documents\StateRegistration\Alagoas;
-use Brazanation\Documents\StateRegistration\Amapa;
-use Brazanation\Documents\StateRegistration\Amazonas;
-use Brazanation\Documents\StateRegistration\Bahia;
-use Brazanation\Documents\StateRegistration\Ceara;
-use Brazanation\Documents\StateRegistration\DistritoFederal;
-use Brazanation\Documents\StateRegistration\EspiritoSanto;
-use Brazanation\Documents\StateRegistration\Goias;
-use Brazanation\Documents\StateRegistration\Maranhao;
-use Brazanation\Documents\StateRegistration\MatoGrosso;
-use Brazanation\Documents\StateRegistration\MatoGrossoSul;
-use Brazanation\Documents\StateRegistration\MinasGerais;
-use Brazanation\Documents\StateRegistration\Para;
-use Brazanation\Documents\StateRegistration\Paraiba;
-use Brazanation\Documents\StateRegistration\Parana;
-use Brazanation\Documents\StateRegistration\Pernambuco;
-use Brazanation\Documents\StateRegistration\Piaui;
-use Brazanation\Documents\StateRegistration\RioDeJaneiro;
-use Brazanation\Documents\StateRegistration\RioGrandeDoNorte;
-use Brazanation\Documents\StateRegistration\RioGrandeDoSul;
-use Brazanation\Documents\StateRegistration\Rondonia;
-use Brazanation\Documents\StateRegistration\Roraima;
-use Brazanation\Documents\StateRegistration\SantaCatarina;
-use Brazanation\Documents\StateRegistration\SaoPaulo;
-use Brazanation\Documents\StateRegistration\Sergipe;
-use Brazanation\Documents\StateRegistration\StateInterface;
-use Brazanation\Documents\StateRegistration\Tocantins;
-
 /**
  * Class StateRegistration
  *
@@ -67,7 +38,7 @@ use Brazanation\Documents\StateRegistration\Tocantins;
 final class StateRegistration extends AbstractDocument
 {
     /**
-     * @var StateInterface
+     * @var StateRegistration\StateInterface
      */
     private $state;
 
@@ -75,42 +46,42 @@ final class StateRegistration extends AbstractDocument
      * @var array
      */
     private static $availableStates = [
-        Acre::SHORT_NAME => Acre::class,
-        Alagoas::SHORT_NAME => Alagoas::class,
-        Amapa::SHORT_NAME => Amapa::class,
-        Amazonas::SHORT_NAME => Amazonas::class,
-        Bahia::SHORT_NAME => Bahia::class,
-        Ceara::SHORT_NAME => Ceara::class,
-        DistritoFederal::SHORT_NAME => DistritoFederal::class,
-        EspiritoSanto::SHORT_NAME => EspiritoSanto::class,
-        Goias::SHORT_NAME => Goias::class,
-        Maranhao::SHORT_NAME => Maranhao::class,
-        MatoGrosso::SHORT_NAME => MatoGrosso::class,
-        MatoGrossoSul::SHORT_NAME => MatoGrossoSul::class,
-        MinasGerais::SHORT_NAME => MinasGerais::class,
-        Para::SHORT_NAME => Para::class,
-        Paraiba::SHORT_NAME => Paraiba::class,
-        Parana::SHORT_NAME => Parana::class,
-        Pernambuco::SHORT_NAME => Pernambuco::class,
-        Piaui::SHORT_NAME => Piaui::class,
-        RioDeJaneiro::SHORT_NAME => RioDeJaneiro::class,
-        RioGrandeDoNorte::SHORT_NAME => RioGrandeDoNorte::class,
-        RioGrandeDoSul::SHORT_NAME => RioGrandeDoSul::class,
-        Rondonia::SHORT_NAME => Rondonia::class,
-        Roraima::SHORT_NAME => Roraima::class,
-        SantaCatarina::SHORT_NAME => SantaCatarina::class,
-        SaoPaulo::SHORT_NAME => SaoPaulo::class,
-        Sergipe::SHORT_NAME => Sergipe::class,
-        Tocantins::SHORT_NAME => Tocantins::class,
+        StateRegistration\Acre::SHORT_NAME => StateRegistration\Acre::class,
+        StateRegistration\Alagoas::SHORT_NAME => StateRegistration\Alagoas::class,
+        StateRegistration\Amapa::SHORT_NAME => StateRegistration\Amapa::class,
+        StateRegistration\Amazonas::SHORT_NAME => StateRegistration\Amazonas::class,
+        StateRegistration\Bahia::SHORT_NAME => StateRegistration\Bahia::class,
+        StateRegistration\Ceara::SHORT_NAME => StateRegistration\Ceara::class,
+        StateRegistration\DistritoFederal::SHORT_NAME => StateRegistration\DistritoFederal::class,
+        StateRegistration\EspiritoSanto::SHORT_NAME => StateRegistration\EspiritoSanto::class,
+        StateRegistration\Goias::SHORT_NAME => StateRegistration\Goias::class,
+        StateRegistration\Maranhao::SHORT_NAME => StateRegistration\Maranhao::class,
+        StateRegistration\MatoGrosso::SHORT_NAME => StateRegistration\MatoGrosso::class,
+        StateRegistration\MatoGrossoSul::SHORT_NAME => StateRegistration\MatoGrossoSul::class,
+        StateRegistration\MinasGerais::SHORT_NAME => StateRegistration\MinasGerais::class,
+        StateRegistration\Para::SHORT_NAME => StateRegistration\Para::class,
+        StateRegistration\Paraiba::SHORT_NAME => StateRegistration\Paraiba::class,
+        StateRegistration\Parana::SHORT_NAME => StateRegistration\Parana::class,
+        StateRegistration\Pernambuco::SHORT_NAME => StateRegistration\Pernambuco::class,
+        StateRegistration\Piaui::SHORT_NAME => StateRegistration\Piaui::class,
+        StateRegistration\RioDeJaneiro::SHORT_NAME => StateRegistration\RioDeJaneiro::class,
+        StateRegistration\RioGrandeDoNorte::SHORT_NAME => StateRegistration\RioGrandeDoNorte::class,
+        StateRegistration\RioGrandeDoSul::SHORT_NAME => StateRegistration\RioGrandeDoSul::class,
+        StateRegistration\Rondonia::SHORT_NAME => StateRegistration\Rondonia::class,
+        StateRegistration\Roraima::SHORT_NAME => StateRegistration\Roraima::class,
+        StateRegistration\SantaCatarina::SHORT_NAME => StateRegistration\SantaCatarina::class,
+        StateRegistration\SaoPaulo::SHORT_NAME => StateRegistration\SaoPaulo::class,
+        StateRegistration\Sergipe::SHORT_NAME => StateRegistration\Sergipe::class,
+        StateRegistration\Tocantins::SHORT_NAME => StateRegistration\Tocantins::class,
     ];
 
     /**
      * StateRegistration constructor.
      *
-     * @param string         $number
-     * @param StateInterface $state
+     * @param string $number
+     * @param StateRegistration\StateInterface $state
      */
-    public function __construct($number, StateInterface $state)
+    public function __construct($number, StateRegistration\StateInterface $state)
     {
         $number = $state->normalizeNumber($number);
         $this->state = $state;
@@ -118,17 +89,36 @@ final class StateRegistration extends AbstractDocument
     }
 
     /**
+     * Try to create a StateRegistration object from given number and state short name.
+     *
+     * @param string $number Document number to be parsed.
+     * @param string $state State short name.
+     *
+     * @return AbstractDocument|boolean Returns a new Document instance or FALSE on failure.
+     */
+    public static function createFromString($number, $state = '')
+    {
+        try {
+            return static::$state($number);
+        } catch (Exception\InvalidDocument $exception) {
+            return false;
+        }
+    }
+
+    /**
      * @param string $name
-     * @param array  $arguments
+     * @param array $arguments
      *
      * @return StateRegistration
+     *
+     * @throws \ReflectionException
      */
     public static function __callStatic($name, $arguments)
     {
         $class = self::$availableStates[$name];
         $reflection = new \ReflectionClass($class);
 
-        /** @var StateInterface $state */
+        /** @var StateRegistration\StateInterface $state */
         $state = $reflection->newInstanceArgs();
 
         return new self($arguments[0], $state);

--- a/src/StateRegistration/Acre.php
+++ b/src/StateRegistration/Acre.php
@@ -16,11 +16,11 @@ final class Acre extends State
 
     const LENGTH = 13;
 
-    const DIGITS_COUNT = 2;
+    const NUMBER_OF_DIGITS = 2;
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Alagoas.php
+++ b/src/StateRegistration/Alagoas.php
@@ -16,11 +16,11 @@ final class Alagoas extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Amapa.php
+++ b/src/StateRegistration/Amapa.php
@@ -16,11 +16,11 @@ final class Amapa extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Amazonas.php
+++ b/src/StateRegistration/Amazonas.php
@@ -16,11 +16,11 @@ final class Amazonas extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Bahia.php
+++ b/src/StateRegistration/Bahia.php
@@ -17,11 +17,11 @@ final class Bahia extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 2;
+    const NUMBER_OF_DIGITS = 2;
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Ceara.php
+++ b/src/StateRegistration/Ceara.php
@@ -14,13 +14,13 @@ final class Ceara extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'CE';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/DistritoFederal.php
+++ b/src/StateRegistration/DistritoFederal.php
@@ -14,13 +14,13 @@ class DistritoFederal extends State
 
     const LENGTH = 13;
 
-    const DIGITS_COUNT = 2;
+    const NUMBER_OF_DIGITS = 2;
 
     const SHORT_NAME = 'DF';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/EspiritoSanto.php
+++ b/src/StateRegistration/EspiritoSanto.php
@@ -14,13 +14,13 @@ final class EspiritoSanto extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'ES';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Goias.php
+++ b/src/StateRegistration/Goias.php
@@ -14,7 +14,7 @@ final class Goias extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'GO';
 
@@ -25,7 +25,7 @@ final class Goias extends State
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Maranhao.php
+++ b/src/StateRegistration/Maranhao.php
@@ -14,13 +14,13 @@ final class Maranhao extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'MA';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/MatoGrosso.php
+++ b/src/StateRegistration/MatoGrosso.php
@@ -14,13 +14,13 @@ class MatoGrosso extends State
 
     const LENGTH = 11;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'MT';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     public function normalizeNumber($number)

--- a/src/StateRegistration/MatoGrossoSul.php
+++ b/src/StateRegistration/MatoGrossoSul.php
@@ -14,13 +14,13 @@ class MatoGrossoSul extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'MS';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/MinasGerais.php
+++ b/src/StateRegistration/MinasGerais.php
@@ -14,13 +14,13 @@ class MinasGerais extends State
 
     const LENGTH = 13;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'MG';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Para.php
+++ b/src/StateRegistration/Para.php
@@ -14,13 +14,13 @@ class Para extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'PA';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Paraiba.php
+++ b/src/StateRegistration/Paraiba.php
@@ -14,13 +14,13 @@ class Paraiba extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'PB';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Parana.php
+++ b/src/StateRegistration/Parana.php
@@ -14,13 +14,13 @@ class Parana extends State
 
     const LENGTH = 10;
 
-    const DIGITS_COUNT = 2;
+    const NUMBER_OF_DIGITS = 2;
 
     const SHORT_NAME = 'PR';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Pernambuco/EFisco.php
+++ b/src/StateRegistration/Pernambuco/EFisco.php
@@ -14,11 +14,11 @@ final class EFisco extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 2;
+    const NUMBER_OF_DIGITS = 2;
 
     public function __construct()
     {
-        parent::__construct(Pernambuco::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(Pernambuco::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Pernambuco/Old.php
+++ b/src/StateRegistration/Pernambuco/Old.php
@@ -14,11 +14,11 @@ class Old extends State
 
     const LENGTH = 14;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     public function __construct()
     {
-        parent::__construct(Pernambuco::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(Pernambuco::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Piaui.php
+++ b/src/StateRegistration/Piaui.php
@@ -14,13 +14,13 @@ class Piaui extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'PI';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/RioDeJaneiro.php
+++ b/src/StateRegistration/RioDeJaneiro.php
@@ -14,13 +14,13 @@ class RioDeJaneiro extends State
 
     const LENGTH = 8;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'RJ';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/RioGrandeDoNorte.php
+++ b/src/StateRegistration/RioGrandeDoNorte.php
@@ -18,7 +18,7 @@ class RioGrandeDoNorte extends State
 
     const LENGTH = 10;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'RN';
 
@@ -42,7 +42,7 @@ class RioGrandeDoNorte extends State
         $this->length = self::LENGTH;
         $this->format = self::FORMAT;
         $this->regex = self::REGEX;
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/RioGrandeDoSul.php
+++ b/src/StateRegistration/RioGrandeDoSul.php
@@ -14,13 +14,13 @@ class RioGrandeDoSul extends State
 
     const LENGTH = 10;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'RS';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Rondonia.php
+++ b/src/StateRegistration/Rondonia.php
@@ -14,13 +14,13 @@ class Rondonia extends State
 
     const LENGTH = 14;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'RO';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Roraima.php
+++ b/src/StateRegistration/Roraima.php
@@ -14,13 +14,13 @@ class Roraima extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'RR';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/SantaCatarina.php
+++ b/src/StateRegistration/SantaCatarina.php
@@ -14,13 +14,13 @@ class SantaCatarina extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'SC';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/SaoPaulo/Rural.php
+++ b/src/StateRegistration/SaoPaulo/Rural.php
@@ -14,11 +14,11 @@ class Rural extends State
 
     const LENGTH = 12;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     public function __construct()
     {
-        parent::__construct(SaoPaulo::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(SaoPaulo::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/SaoPaulo/Urban.php
+++ b/src/StateRegistration/SaoPaulo/Urban.php
@@ -14,11 +14,11 @@ class Urban extends State
 
     const LENGTH = 12;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     public function __construct()
     {
-        parent::__construct(SaoPaulo::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(SaoPaulo::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Sergipe.php
+++ b/src/StateRegistration/Sergipe.php
@@ -14,13 +14,13 @@ class Sergipe extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     const SHORT_NAME = 'SE';
 
     public function __construct()
     {
-        parent::__construct(self::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(self::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Tocantins/Eleven.php
+++ b/src/StateRegistration/Tocantins/Eleven.php
@@ -14,11 +14,11 @@ class Eleven extends State
 
     const LENGTH = 11;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     public function __construct()
     {
-        parent::__construct(Tocantins::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(Tocantins::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/StateRegistration/Tocantins/Nine.php
+++ b/src/StateRegistration/Tocantins/Nine.php
@@ -14,11 +14,11 @@ class Nine extends State
 
     const LENGTH = 9;
 
-    const DIGITS_COUNT = 1;
+    const NUMBER_OF_DIGITS = 1;
 
     public function __construct()
     {
-        parent::__construct(Tocantins::LONG_NAME, self::LENGTH, self::DIGITS_COUNT, self::REGEX, self::FORMAT);
+        parent::__construct(Tocantins::LONG_NAME, self::LENGTH, self::NUMBER_OF_DIGITS, self::REGEX, self::FORMAT);
     }
 
     /**

--- a/src/Voter.php
+++ b/src/Voter.php
@@ -8,6 +8,8 @@ final class Voter extends AbstractDocument
 
     const LABEL = 'Voter';
 
+    const NUMBER_OF_DIGITS = 2;
+
     private $section;
 
     private $zone;
@@ -22,10 +24,15 @@ final class Voter extends AbstractDocument
     public function __construct($number, $section = null, $zone = null)
     {
         $number = preg_replace('/\D/', '', $number);
-        parent::__construct($number, self::LENGTH, 2, self::LABEL);
+        parent::__construct($number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
 
         $this->section = str_pad($section, 4, '0', STR_PAD_LEFT);
         $this->zone = str_pad($zone, 3, '0', STR_PAD_LEFT);
+    }
+
+    public static function createFromString($number, $section = null, $zone = null)
+    {
+        return parent::tryCreateFromString(self::class, $number, self::LENGTH, self::NUMBER_OF_DIGITS, self::LABEL);
     }
 
     /**

--- a/tests/CnhTest.php
+++ b/tests/CnhTest.php
@@ -11,6 +11,11 @@ class CnhTest extends DocumentTestCase
         return new Cnh($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return Cnh::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/CnpjTest.php
+++ b/tests/CnpjTest.php
@@ -11,6 +11,11 @@ class CnpjTest extends DocumentTestCase
         return new Cnpj($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return Cnpj::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/CnsTest.php
+++ b/tests/CnsTest.php
@@ -11,6 +11,11 @@ class CnsTest extends DocumentTestCase
         return new Cns($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return Cns::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/CpfTest.php
+++ b/tests/CpfTest.php
@@ -11,6 +11,11 @@ class CpfTest extends DocumentTestCase
         return new Cpf($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return Cpf::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/DocumentTestCase.php
+++ b/tests/DocumentTestCase.php
@@ -16,6 +16,13 @@ abstract class DocumentTestCase extends TestCase
     abstract public function createDocument($number);
 
     /**
+     * @param string $number
+     *
+     * @return AbstractDocument|boolean
+     */
+    abstract public function createDocumentFromString($number);
+
+    /**
      * Provides a list of valid numbers
      *
      * @return array
@@ -56,6 +63,18 @@ abstract class DocumentTestCase extends TestCase
     }
 
     /**
+     * @param string $number
+     *
+     * @dataProvider provideValidNumbers
+     */
+    final public function testShouldCreateInstanceFromString($number)
+    {
+        $document = $this->createDocumentFromString($number);
+        $this->assertInstanceOf(AbstractDocument::class, $document);
+        $this->assertEquals(preg_replace('/[^\dXP]/i', '', $number), (string) $document);
+    }
+
+    /**
      * @param string $number         Number of document
      * @param string $expectedFormat Formatted number
      *
@@ -64,6 +83,18 @@ abstract class DocumentTestCase extends TestCase
     final public function testShouldFormatDocument($number, $expectedFormat)
     {
         $document = $this->createDocument($number);
+        $this->assertEquals($expectedFormat, $document->format());
+    }
+
+    /**
+     * @param string $number         Number of document
+     * @param string $expectedFormat Formatted number
+     *
+     * @dataProvider provideValidNumbersAndExpectedFormat
+     */
+    final public function testShouldFormatDocumentFromString($number, $expectedFormat)
+    {
+        $document = $this->createDocumentFromString($number);
         $this->assertEquals($expectedFormat, $document->format());
     }
 
@@ -84,6 +115,18 @@ abstract class DocumentTestCase extends TestCase
      * @param string $documentType
      * @param string $number
      *
+     * @dataProvider provideEmptyData
+     */
+    final public function testShouldReturnsFalseForEmptyData($documentType, $number)
+    {
+        $document = $this->createDocumentFromString($number);
+        $this->assertFalse($document, "Failed asserting that {$documentType} is not valid");
+    }
+
+    /**
+     * @param string $documentType
+     * @param string $number
+     *
      * @dataProvider provideInvalidNumber
      */
     public function testShouldThrowExceptionForInvalidNumbers($documentType, $number)
@@ -92,5 +135,17 @@ abstract class DocumentTestCase extends TestCase
         $this->expectException(InvalidDocument::class);
         $this->expectExceptionMessage("The {$documentType}($numberSanitized) is not valid");
         $this->createDocument($number);
+    }
+
+    /**
+     * @param string $documentType
+     * @param string $number
+     *
+     * @dataProvider provideInvalidNumber
+     */
+    public function testShouldReturnsFalseForInvalidNumbers($documentType, $number)
+    {
+        $document = $this->createDocumentFromString($number);
+        $this->assertFalse($document, "Failed asserting that {$documentType} is not valid");
     }
 }

--- a/tests/JudiciaryProcessTest.php
+++ b/tests/JudiciaryProcessTest.php
@@ -11,6 +11,11 @@ class JudiciaryProcessTest extends DocumentTestCase
         return new JudiciaryProcess($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return JudiciaryProcess::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/PisPasepTest.php
+++ b/tests/PisPasepTest.php
@@ -11,6 +11,11 @@ class PisPasepTest extends DocumentTestCase
         return new PisPasep($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return PisPasep::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/RenavamTest.php
+++ b/tests/RenavamTest.php
@@ -11,6 +11,11 @@ class RenavamTest extends DocumentTestCase
         return new Renavam($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return Renavam::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/Sped/CTeOtherTest.php
+++ b/tests/Sped/CTeOtherTest.php
@@ -14,6 +14,11 @@ class CTeOtherTest extends DocumentTestCase
         return new CTeOther($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return CTeOther::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/Sped/CTeTest.php
+++ b/tests/Sped/CTeTest.php
@@ -14,6 +14,11 @@ class CTeTest extends DocumentTestCase
         return new CTe($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return CTe::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/Sped/MDFeTest.php
+++ b/tests/Sped/MDFeTest.php
@@ -14,6 +14,11 @@ class MDFeTest extends TestCase
         return new MDFe($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return MDFe::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/Sped/NFCeTest.php
+++ b/tests/Sped/NFCeTest.php
@@ -14,6 +14,11 @@ class NFCeTest extends DocumentTestCase
         return new NFCe($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return NFCe::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/Sped/NFeTest.php
+++ b/tests/Sped/NFeTest.php
@@ -14,6 +14,11 @@ class NFeTest extends DocumentTestCase
         return new NFe($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return NFe::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/AcreTest.php
+++ b/tests/StateRegistration/AcreTest.php
@@ -13,6 +13,11 @@ class AcreTest extends DocumentTestCase
         return StateRegistration::AC($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Acre::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/AlagoasTest.php
+++ b/tests/StateRegistration/AlagoasTest.php
@@ -13,6 +13,11 @@ class AlagoasTest extends DocumentTestCase
         return StateRegistration::AL($number);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Alagoas::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/AmapaTest.php
+++ b/tests/StateRegistration/AmapaTest.php
@@ -13,6 +13,11 @@ class AmapaTest extends DocumentTestCase
         return new StateRegistration($number, new Amapa());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Amapa::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/AmazonasTest.php
+++ b/tests/StateRegistration/AmazonasTest.php
@@ -13,6 +13,11 @@ class AmazonasTest extends DocumentTestCase
         return new StateRegistration($number, new Amazonas());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Amazonas::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/BahiaTest.php
+++ b/tests/StateRegistration/BahiaTest.php
@@ -13,6 +13,11 @@ class BahiaTest extends DocumentTestCase
         return new StateRegistration($number, new Bahia());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Bahia::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/CearaTest.php
+++ b/tests/StateRegistration/CearaTest.php
@@ -13,6 +13,11 @@ class CearaTest extends DocumentTestCase
         return new StateRegistration($number, new Ceara());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Ceara::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/DistritoFederalTest.php
+++ b/tests/StateRegistration/DistritoFederalTest.php
@@ -13,6 +13,11 @@ class DistritoFederalTest extends DocumentTestCase
         return new StateRegistration($number, new DF());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, DF::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/EspiritoSantoTest.php
+++ b/tests/StateRegistration/EspiritoSantoTest.php
@@ -13,6 +13,11 @@ class EspiritoSantoTest extends DocumentTestCase
         return new StateRegistration($number, new EspiritoSanto());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, EspiritoSanto::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/GoiasTest.php
+++ b/tests/StateRegistration/GoiasTest.php
@@ -13,6 +13,11 @@ class GoiasTest extends DocumentTestCase
         return new StateRegistration($number, new Goias());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Goias::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/MaranhaoTest.php
+++ b/tests/StateRegistration/MaranhaoTest.php
@@ -13,6 +13,11 @@ class MaranhaoTest extends DocumentTestCase
         return new StateRegistration($number, new Maranhao());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Maranhao::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/MatoGrossoSulTest.php
+++ b/tests/StateRegistration/MatoGrossoSulTest.php
@@ -13,6 +13,11 @@ class MatoGrossoSulTest extends DocumentTestCase
         return new StateRegistration($number, new MatoGrossoSul());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, MatoGrossoSul::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/MatoGrossoTest.php
+++ b/tests/StateRegistration/MatoGrossoTest.php
@@ -13,6 +13,11 @@ class MatoGrossoTest extends DocumentTestCase
         return new StateRegistration($number, new MatoGrosso());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, MatoGrosso::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/MinasGeraisTest.php
+++ b/tests/StateRegistration/MinasGeraisTest.php
@@ -13,6 +13,11 @@ class MinasGeraisTest extends DocumentTestCase
         return new StateRegistration($number, new MG());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, MG::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/ParaTest.php
+++ b/tests/StateRegistration/ParaTest.php
@@ -13,6 +13,11 @@ class ParaTest extends DocumentTestCase
         return new StateRegistration($number, new Para());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Para::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/ParaibaTest.php
+++ b/tests/StateRegistration/ParaibaTest.php
@@ -13,6 +13,11 @@ class ParaibaTest extends DocumentTestCase
         return new StateRegistration($number, new Paraiba());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Paraiba::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/ParanaTest.php
+++ b/tests/StateRegistration/ParanaTest.php
@@ -13,6 +13,11 @@ class ParanaTest extends DocumentTestCase
         return new StateRegistration($number, new Parana());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Parana::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/PernambucoTest.php
+++ b/tests/StateRegistration/PernambucoTest.php
@@ -13,6 +13,11 @@ class PernambucoTest extends DocumentTestCase
         return new StateRegistration($number, new Pernambuco());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Pernambuco::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/PiauiTest.php
+++ b/tests/StateRegistration/PiauiTest.php
@@ -13,6 +13,11 @@ class PiauiTest extends DocumentTestCase
         return new StateRegistration($number, new Piaui());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Piaui::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/RioDeJaneiroTest.php
+++ b/tests/StateRegistration/RioDeJaneiroTest.php
@@ -13,6 +13,11 @@ class RioDeJaneiroTest extends DocumentTestCase
         return new StateRegistration($number, new RioDeJaneiro());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, RioDeJaneiro::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/RioGrandeDoNorteTest.php
+++ b/tests/StateRegistration/RioGrandeDoNorteTest.php
@@ -13,6 +13,11 @@ class RioGrandeDoNorteTest extends DocumentTestCase
         return new StateRegistration($number, new RioGrandeDoNorte());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, RioGrandeDoNorte::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/RioGrandeDoSulTest.php
+++ b/tests/StateRegistration/RioGrandeDoSulTest.php
@@ -13,6 +13,11 @@ class RioGrandeDoSulTest extends DocumentTestCase
         return new StateRegistration($number, new RioGrandeDoSul());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, RioGrandeDoSul::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/RondoniaTest.php
+++ b/tests/StateRegistration/RondoniaTest.php
@@ -13,6 +13,11 @@ class RondoniaTest extends DocumentTestCase
         return new StateRegistration($number, new Rondonia());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Rondonia::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/RoraimaTest.php
+++ b/tests/StateRegistration/RoraimaTest.php
@@ -13,6 +13,11 @@ class RoraimaTest extends DocumentTestCase
         return new StateRegistration($number, new Roraima());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Roraima::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/SantaCatarinaTest.php
+++ b/tests/StateRegistration/SantaCatarinaTest.php
@@ -13,6 +13,11 @@ class SantaCatarinaTest extends DocumentTestCase
         return new StateRegistration($number, new SantaCatarina());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, SantaCatarina::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/SaoPauloTest.php
+++ b/tests/StateRegistration/SaoPauloTest.php
@@ -13,6 +13,11 @@ class SaoPauloTest extends DocumentTestCase
         return new StateRegistration($number, new SaoPaulo());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, SaoPaulo::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/SergipeTest.php
+++ b/tests/StateRegistration/SergipeTest.php
@@ -13,6 +13,11 @@ class SergipeTest extends DocumentTestCase
         return new StateRegistration($number, new Sergipe());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Sergipe::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/StateRegistration/TocantinsTest.php
+++ b/tests/StateRegistration/TocantinsTest.php
@@ -13,6 +13,11 @@ class TocantinsTest extends DocumentTestCase
         return new StateRegistration($number, new Tocantins());
     }
 
+    public function createDocumentFromString($number)
+    {
+        return StateRegistration::createFromString($number, Tocantins::SHORT_NAME);
+    }
+
     public function provideValidNumbers()
     {
         return [

--- a/tests/VoterTest.php
+++ b/tests/VoterTest.php
@@ -11,6 +11,11 @@ class VoterTest extends DocumentTestCase
         return new Voter($number, null, null);
     }
 
+    public function createDocumentFromString($number)
+    {
+        return Voter::createFromString($number);
+    }
+
     public function provideValidNumbers()
     {
         return [


### PR DESCRIPTION
Trying to keep simple to use and avoid throw exception on construct
object with invalid document numbers.

Create an object from given string is similar behaviour from
DateTime::createFromFormat, when give a valid number it returns an
document object or FALSE when failure.