### PR TITLE
Minimo ajuste para permitir o uso do pacote em PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Provides Brazilian Documents",
     "type": "library",
     "require": {
-        "php": "^7.0"
+        "php": ">=7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4",
@@ -25,5 +25,8 @@
         "psr-4": {
             "Brazanation\\Documents\\Tests\\": "tests"
         }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit -c phpunit.xml.dist"
     }
 }


### PR DESCRIPTION
Não foi alterados nenhum outro arquivo, apenas o composer.json.
Porém futuramente será necessário refatorar o testes unitários, pois não são compatíveis com as versões mais atuais do phpunit.
Processei todos os documentos em ambiente com php8, sem erros nos códigos.